### PR TITLE
Copy default config.toml on install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ install: target/release/crosspub
 	cp target/release/crosspub /usr/local/bin
 	mkdir -p /usr/share/crosspub
 	cp -r templates /usr/share/crosspub/
+	cp config.toml /usr/share/crosspub/
 
 uninstall:
 	rm /usr/local/bin/crosspub


### PR DESCRIPTION
Currently the default config file isn't copied on install. I don't have a Rust toolchain set up so I haven't tested it, but I think this should work. Thanks for putting this together, I'm looking forward to using it!